### PR TITLE
Support Go 1.7 and CLI version 6.22.1

### DIFF
--- a/blue_green_deploy.go
+++ b/blue_green_deploy.go
@@ -8,9 +8,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/cloudfoundry/cli/cf/configuration/confighelpers"
-	"github.com/cloudfoundry/cli/cf/configuration/coreconfig"
-	"github.com/cloudfoundry/cli/plugin"
+	"code.cloudfoundry.org/cli/cf/configuration/confighelpers"
+	"code.cloudfoundry.org/cli/cf/configuration/coreconfig"
+	"code.cloudfoundry.org/cli/plugin"
 )
 
 type ErrorHandler func(string, error)
@@ -161,11 +161,12 @@ func (l *CfCurlAppLister) AppsInCurrentSpace() ([]Application, error) {
 }
 
 func getSpaceGuid() string {
-	configRepo := coreconfig.NewRepositoryFromFilepath(confighelpers.DefaultFilePath(), func(err error) {
+	path, _ := confighelpers.DefaultFilePath()
+	configRepo := coreconfig.NewRepositoryFromFilepath(path, func(err error) {
 		if err != nil {
 			fmt.Printf("Config error: %s", err)
 		}
 	})
 
-	return configRepo.SpaceFields().Guid
+	return configRepo.SpaceFields().GUID
 }

--- a/blue_green_deploy.go
+++ b/blue_green_deploy.go
@@ -152,11 +152,13 @@ func (l *CfCurlAppLister) AppsInCurrentSpace() ([]Application, error) {
 		return nil, err
 	}
 
+	var joined_output = strings.Join(output, "\n")
+
 	apps := struct {
 		Apps []Application
 	}{}
 
-	json.Unmarshal([]byte(output[0]), &apps)
+	json.Unmarshal([]byte(joined_output), &apps)
 	return apps.Apps, nil
 }
 

--- a/blue_green_deploy_test.go
+++ b/blue_green_deploy_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	. "github.com/bluemixgaragelondon/cf-blue-green-deploy"
-	"github.com/cloudfoundry/cli/plugin/pluginfakes"
+	"code.cloudfoundry.org/cli/plugin/pluginfakes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func (p *CfPlugin) Deploy(defaultCfDomain string, repo manifest.Repository, args
 	}
 }
 
-func (p *CfPlugin) GetNewAppRoutes(appName string, defaultCfDomain string, repo manifest.Repository, liveAppRoutes []Route) []Route{
+func (p *CfPlugin) GetNewAppRoutes(appName string, defaultCfDomain string, repo manifest.Repository, liveAppRoutes []Route) []Route {
 	newAppRoutes := []Route{}
 	f := ManifestAppFinder{AppName: appName, Repo: repo}
 	if manifestRoutes := f.RoutesFromManifest(defaultCfDomain); manifestRoutes != nil {

--- a/main.go
+++ b/main.go
@@ -6,10 +6,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cloudfoundry/cli/cf/i18n"
-	"github.com/cloudfoundry/cli/cf/manifest"
-	"github.com/cloudfoundry/cli/plugin"
-	go_i18n "github.com/nicksnyder/go-i18n/i18n"
+	"code.cloudfoundry.org/cli/cf/manifest"
+	"code.cloudfoundry.org/cli/plugin"
+	"strings"
 )
 
 var PluginVersion string
@@ -39,13 +38,13 @@ func (p *CfPlugin) Run(cliConnection plugin.CliConnection, args []string) {
 		os.Exit(1)
 	}
 
-	if !p.Deploy(defaultCfDomain, manifest.ManifestDiskRepository{}, args) {
+	if !p.Deploy(defaultCfDomain, manifest.DiskRepository{}, args) {
 		fmt.Println("Smoke tests failed")
 		os.Exit(1)
 	}
 }
 
-func (p *CfPlugin) Deploy(defaultCfDomain string, repo manifest.ManifestRepository, args []string) bool {
+func (p *CfPlugin) Deploy(defaultCfDomain string, repo manifest.Repository, args []string) bool {
 	appName := args[1]
 
 	p.Deployer.DeleteAllAppsExceptLiveApp(appName)
@@ -82,7 +81,7 @@ func (p *CfPlugin) Deploy(defaultCfDomain string, repo manifest.ManifestReposito
 	}
 }
 
-func (p *CfPlugin) GetNewAppRoutes(appName string, defaultCfDomain string, repo manifest.ManifestRepository, liveAppRoutes []Route) []Route{
+func (p *CfPlugin) GetNewAppRoutes(appName string, defaultCfDomain string, repo manifest.Repository, liveAppRoutes []Route) []Route{
 	newAppRoutes := []Route{}
 	f := ManifestAppFinder{AppName: appName, Repo: repo}
 	if manifestRoutes := f.RoutesFromManifest(defaultCfDomain); manifestRoutes != nil {
@@ -153,7 +152,10 @@ func (p *CfPlugin) DefaultCfDomain() (domain string, err error) {
 		}
 	}{}
 
-	if err = json.Unmarshal([]byte(res[0]), &response); err != nil {
+	var json_string string
+	json_string = strings.Join(res, "\n")
+
+	if err = json.Unmarshal([]byte(json_string), &response); err != nil {
 		return
 	}
 
@@ -169,8 +171,6 @@ func ExtractIntegrationTestScript(args []string) string {
 }
 
 func main() {
-	// T needs to point to a translate func, otherwise cf internals blow up
-	i18n.T, _ = go_i18n.Tfunc("")
 	p := CfPlugin{
 		Deployer: &BlueGreenDeploy{
 			ErrorFunc: func(message string, err error) {

--- a/main_test.go
+++ b/main_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	. "github.com/bluemixgaragelondon/cf-blue-green-deploy"
-	"github.com/cloudfoundry/cli/plugin"
-	"github.com/cloudfoundry/cli/plugin/pluginfakes"
+	"code.cloudfoundry.org/cli/plugin"
+	"code.cloudfoundry.org/cli/plugin/pluginfakes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/manifest.go
+++ b/manifest.go
@@ -3,14 +3,14 @@ package main
 import (
 	"fmt"
 
-	"github.com/cloudfoundry/cli/cf/manifest"
-	"github.com/cloudfoundry/cli/cf/models"
+	"code.cloudfoundry.org/cli/cf/manifest"
+	"code.cloudfoundry.org/cli/cf/models"
 )
 
-type ManifestReader func(manifest.ManifestRepository, string) *models.AppParams
+type ManifestReader func(manifest.Repository, string) *models.AppParams
 
 type ManifestAppFinder struct {
-	Repo    manifest.ManifestRepository
+	Repo    manifest.Repository
 	AppName string
 }
 
@@ -19,13 +19,13 @@ func (f *ManifestAppFinder) RoutesFromManifest(defaultDomain string) []Route {
 
 		manifestRoutes := make([]Route, 0)
 
-		for _, host := range *appParams.Hosts {
+		for _, host := range appParams.Hosts {
 			if appParams.Domains == nil {
 				manifestRoutes = append(manifestRoutes, Route{Host: host, Domain: Domain{Name: defaultDomain}})
 				continue
 			}
 
-			for _, domain := range *appParams.Domains {
+			for _, domain := range appParams.Domains {
 				manifestRoutes = append(manifestRoutes, Route{Host: host, Domain: Domain{Name: domain}})
 			}
 		}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -5,17 +5,23 @@ import (
 
 	. "github.com/bluemixgaragelondon/cf-blue-green-deploy"
 	"github.com/cloudfoundry-incubator/candiedyaml"
-	"github.com/cloudfoundry/cli/cf/i18n"
-	"github.com/cloudfoundry/cli/cf/manifest"
-	"github.com/cloudfoundry/cli/generic"
-	go_i18n "github.com/nicksnyder/go-i18n/i18n"
+	"code.cloudfoundry.org/cli/cf/manifest"
+	"code.cloudfoundry.org/cli/cf/i18n"
+	"code.cloudfoundry.org/cli/utils/generic"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
+type localeGetter struct{}
+
+func (l localeGetter) Locale() string {
+	return "en-us"
+}
+
 var _ = Describe("Manifest reader", func() {
+
 	// testing code that calls into cf cli requires T to point to a translate func
-	i18n.T, _ = go_i18n.Tfunc("")
+	i18n.T = i18n.Init(localeGetter{})
 
 	Context("When the manifest file is present", func() {
 		Context("when the manifest contain a host but no app name", func() {
@@ -25,7 +31,7 @@ var _ = Describe("Manifest reader", func() {
 			manifestAppFinder := ManifestAppFinder{AppName: "foo", Repo: &repo}
 
 			It("Returns params that contain the host", func() {
-				Expect(*manifestAppFinder.AppParams().Hosts).To(ContainElement("foo"))
+				Expect(manifestAppFinder.AppParams().Hosts).To(ContainElement("foo"))
 			})
 		})
 
@@ -58,8 +64,8 @@ var _ = Describe("Manifest reader", func() {
 
 			It("Returns the correct app", func() {
 				Expect(*manifestAppFinder.AppParams().Name).To(Equal("foo"))
-				Expect(*manifestAppFinder.AppParams().Hosts).To(ConsistOf("host1", "host2"))
-				Expect(*manifestAppFinder.AppParams().Domains).To(ConsistOf("example1.com", "example2.com"))
+				Expect(manifestAppFinder.AppParams().Hosts).To(ConsistOf("host1", "host2"))
+				Expect(manifestAppFinder.AppParams().Domains).To(ConsistOf("example1.com", "example2.com"))
 			})
 		})
 	})

--- a/script/deps
+++ b/script/deps
@@ -2,7 +2,7 @@
 
 [ -z "$DEBUG" ] || set -x
 
-CF_CLI_VERSION="v6.17.0"
+CF_CLI_VERSION="v6.22.1"
 
  . script/common
 GO_PACKAGE_PATH=$(get_go_package_dir)


### PR DESCRIPTION
This commit updates the bgd plugin to compile with go 1.7
following the suggestions in issue #13 and fixes the
**Failed to get default shared domain** error reported in issue #11.

The **Failed to get default shared domain** error was happening because
of a change in the behaviour of
`CfPlugin.Connection.CliCommandWithoutTerminalOutput`
which used to return a `[]string` with the entire contents of the
response in index 0. It now returns the output of the CliCommand split
by "\n". So we need to join it again before trying to unmarshall it.
