### PR TITLE
Read acceptance test app names from environment

### DIFF
--- a/.env
+++ b/.env
@@ -14,3 +14,5 @@ export PLUGIN_VERSION="${PLUGIN_VERSION:-1.1.0}"
 export APP_PKG_NAME="github.com/bluemixgaragelondon/cf-blue-green-deploy"
 
 export TEST_ACCEPTANCE_LOG="/tmp/test_acceptance.log"
+export TEST_ACCEPTANCE_APP_NAME="${TEST_ACCEPTANCE_APP_NAME:=cf-blue-green-deploy-test-app}"
+export TEST_ACCEPTANCE_APP_HOSTNAME="${TEST_ACCEPTANCE_APP_HOSTNAME:=cf-bgd}"

--- a/script/common
+++ b/script/common
@@ -39,9 +39,11 @@ install_plugin() {
 push_example_apps() {
   pushd acceptance/app
     login_to_bluemix
-    cf push cf-blue-green-deploy-test-app-old
-    cf push cf-blue-green-deploy-test-app
-    cf map-route cf-blue-green-deploy-test-app eu-gb.mybluemix.net -n "$CF_SPACE"
+    local app_name="$1"
+    local app_host_name="$2"
+    cf push "${app_name}-old"
+    cf push "$app_name"
+    cf map-route "$app_name" eu-gb.mybluemix.net -n "$app_host_name"
   popd
 }
 

--- a/script/test_acceptance
+++ b/script/test_acceptance
@@ -14,8 +14,9 @@ main() {
 
   if [ -z "$TURBO" ]
   then
-
-    push_example_apps
+    TEST_ACCEPTANCE_APP_HOSTNAME="${TEST_ACCEPTANCE_APP_HOSTNAME:?Must be defined in .env}"
+    TEST_ACCEPTANCE_APP_NAME="${TEST_ACCEPTANCE_APP_NAME:=$TEST_ACCEPTANCE_APP_HOSTNAME}"
+    push_example_apps "$TEST_ACCEPTANCE_APP_NAME" "$TEST_ACCEPTANCE_APP_HOSTNAME"
   fi
 
   pushd acceptance/app >/dev/null
@@ -37,7 +38,7 @@ assert_plugin_output_includes_successful_smoke_test_output() {
   local smoke_test_script="script/smoke_test"
   local smoke_test_output="Hello world from my Go program!"
 
-  cf bgd cf-blue-green-deploy-test-app --smoke-test "$smoke_test_script" | tee "$TEST_ACCEPTANCE_LOG"
+  cf bgd "$ACCEPTANCE_HOSTNAME" --smoke-test "$smoke_test_script" | tee "$TEST_ACCEPTANCE_LOG"
 
   if ! grep "$smoke_test_output" "$TEST_ACCEPTANCE_LOG"
   then
@@ -53,7 +54,7 @@ assert_plugin_fails_if_smoke_test_script_fails() {
   local expected_output_last_line="Smoke tests failed"
 
 	set -o pipefail
-  cf bgd cf-blue-green-deploy-test-app-FORCE-SMOKE-TEST-FAILURE --smoke-test $smoke_test_script | tee "$TEST_ACCEPTANCE_LOG"
+  cf bgd "${ACCEPTANCE_HOSTNAME}-FORCE-SMOKE-TEST-FAILURE" --smoke-test $smoke_test_script | tee "$TEST_ACCEPTANCE_LOG"
 	local cf_bgd_exit_code=$?
 
   if [ $cf_bgd_exit_code != 1 ]


### PR DESCRIPTION
This is required to ensure the test app uses a route
that is unique for various bluemix accounts.
This eliminates a bug where $CF_SPACE was being used
as the hostname for running acceptance tests.
Defaults are provided in .env file.