### PR TITLE
Correct version number

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ export GOPATH="${GOPATH:-${WORKSPACE}}"
 export PATH="${GOPATH}/bin:${PATH}"
 
 export PLUGIN_NAME="blue-green-deploy"
-export PLUGIN_VERSION="${PLUGIN_VERSION:-1.1.0}"
+export PLUGIN_VERSION="${PLUGIN_VERSION:-1.2.0}"
 
 export APP_PKG_NAME="github.com/bluemixgaragelondon/cf-blue-green-deploy"
 


### PR DESCRIPTION
v1.2.0 of the plugin self-reports that it's v1.1.0.

```
$ cf install-plugin https://github.com/bluemixgaragelondon/cf-blue-green-deploy/releases/download/v1.2.0/blue-green-deploy.osx

**Attention: Plugins are binaries written by potentially untrusted authors. Install and use plugins at your own risk.**

Do you want to install the plugin https://github.com/bluemixgaragelondon/cf-blue-green-deploy/releases/download/v1.2.0/blue-green-deploy.osx? (y or n)> y

Attempting to download binary file from internet address...
10765888 bytes downloaded...
Installing plugin blue-green-deploy.osx...
OK
Plugin blue-green-deploy v1.1.0 successfully installed.
developer-training-course git:(master) $ cf plugins
Listing Installed Plugins...
OK

Plugin Name         Version   Command Name             Command Help
blue-green-deploy   1.1.0     blue-green-deploy, bgd   Zero-downtime deploys with smoke tests
```