### PR TITLE
Add provision to unmap path from applications with context path

### DIFF
--- a/blue_green_deploy.go
+++ b/blue_green_deploy.go
@@ -175,7 +175,12 @@ func (p *BlueGreenDeploy) mapRoute(appName string, r plugin_models.GetApp_RouteS
 }
 
 func (p *BlueGreenDeploy) unmapRoute(appName string, r plugin_models.GetApp_RouteSummary) {
-	if _, err := p.Connection.CliCommand("unmap-route", appName, r.Domain.Name, "-n", r.Host); err != nil {
+	command := []string{"unmap-route", appName, r.Domain.Name, "-n", r.Host}
+	if len(r.Path) != 0 {
+		command = append(command, "--path")
+		command = append(command, r.Path)
+	}
+	if _, err := p.Connection.CliCommand(command...); err != nil {
 		p.ErrorFunc("Could not unmap route", err)
 	}
 }

--- a/blue_green_deploy_test.go
+++ b/blue_green_deploy_test.go
@@ -84,6 +84,24 @@ var _ = Describe("BlueGreenDeploy", func() {
 				"unmap-route old example.com -n live",
 			}))
 		})
+
+		It("unmaps routes from old app with paths", func() {
+			oldApp = plugin_models.GetAppModel{
+				Name: "old",
+				Routes: []plugin_models.GetApp_RouteSummary{
+					{Host: "live", Domain: plugin_models.GetApp_DomainFields{Name: "mybluemix.net"}, Path: "my/context/path1"},
+					{Host: "live", Domain: plugin_models.GetApp_DomainFields{Name: "example.com"}, Path: "my/context/path2"},
+				},
+			}
+			p.UnmapRoutesFromApp(oldApp.Name, oldApp.Routes...)
+
+			cfCommands := getAllCfCommands(connection)
+
+			Expect(cfCommands).To(Equal([]string{
+				"unmap-route old mybluemix.net -n live --path my/context/path1",
+				"unmap-route old example.com -n live --path my/context/path2",
+			}))
+		})
 	})
 
 	Describe("renaming an app", func() {


### PR DESCRIPTION
- This change should be backward compatible
- If the application has a Path set in route, then honor that while doing unmap-route
- Otherwise the script would fail stating 'route not found'