### PR TITLE
Remove unnecessary nil guard

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -204,11 +204,7 @@ func mapToAppParams(basePath string, yamlMap map[string]interface{}, cfDomains C
 
 	domainAry := sliceOrNil(yamlMap, "domains", &errs)
 	if domain := stringVal(yamlMap, "domain", &errs); domain != nil {
-		if domainAry == nil {
-			domainAry = []string{*domain}
-		} else {
-			domainAry = append(domainAry, *domain)
-		}
+		domainAry = append(domainAry, *domain)
 	}
 	mytempDomainsObject := removeDuplicatedValue(domainAry)
 

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -300,6 +300,24 @@ hosts:
 				})
 			})
 
+			Context("when app has just one host and one domain", func() {
+				It("returns Application", func() {
+					manifest := manifestFromYamlString(`---
+name: foo
+host: host
+domain: domain.com`)
+
+					params := manifest.GetAppParams("foo", CfDomains{DefaultDomain: "example.com"})
+					Expect(params).ToNot(BeNil())
+					Expect(params.Routes).ToNot(BeNil())
+
+					routes := params.Routes
+					Expect(routes).To(ConsistOf(
+						plugin_models.GetApp_RouteSummary{Host: "host", Domain: plugin_models.GetApp_DomainFields{Name: "domain.com"}},
+					))
+				})
+			})
+
 			Context("when app has just routes, no hosts or domains", func() {
 				It("returns those routes", func() {
 					manifest := manifestFromYamlString(`---


### PR DESCRIPTION
* treat 'domainAry' in the same way as 'hostsArr'
* add test case which checks manifest with exactly one 'domain: ' entry