### PR TITLE
Copy ssh enablement state to new application

### DIFF
--- a/blue_green_deploy.go
+++ b/blue_green_deploy.go
@@ -23,6 +23,8 @@ type BlueGreenDeployer interface {
 	UnmapRoutesFromApp(string, ...plugin_models.GetApp_RouteSummary)
 	RenameApp(string, string)
 	MapRoutesToApp(string, ...plugin_models.GetApp_RouteSummary)
+	CheckSshEnablement(string) bool
+	SetSshAccess(string, bool)
 }
 
 type BlueGreenDeploy struct {
@@ -189,5 +191,26 @@ func (p *BlueGreenDeploy) RenameApp(app string, newName string) {
 func (p *BlueGreenDeploy) MapRoutesToApp(appName string, routes ...plugin_models.GetApp_RouteSummary) {
 	for _, route := range routes {
 		p.mapRoute(appName, route)
+	}
+}
+
+func (p *BlueGreenDeploy) CheckSshEnablement(app string) bool {
+	if result, err := p.Connection.CliCommand("ssh-enabled", app); err != nil {
+		p.ErrorFunc("Check ssh enabled status failed", err)
+		return true
+	} else {
+		return (strings.Contains(result[0], "support is enabled"))
+	}
+}
+
+func (p *BlueGreenDeploy) SetSshAccess(app string, enableSsh bool) {
+	if enableSsh {
+		if _, err := p.Connection.CliCommand("enable-ssh", app); err != nil {
+			p.ErrorFunc("Could not enable ssh", err)
+		}
+	} else {
+		if _, err := p.Connection.CliCommand("disable-ssh", app); err != nil {
+			p.ErrorFunc("Could not disable ssh", err)
+		}
 	}
 }

--- a/blue_green_deploy_test.go
+++ b/blue_green_deploy_test.go
@@ -7,6 +7,7 @@ import (
 
 	"code.cloudfoundry.org/cli/plugin/models"
 	"code.cloudfoundry.org/cli/plugin/pluginfakes"
+	"fmt"
 	. "github.com/bluemixgaragelondon/cf-blue-green-deploy"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -83,6 +84,106 @@ var _ = Describe("BlueGreenDeploy", func() {
 				"unmap-route old mybluemix.net -n live",
 				"unmap-route old example.com -n live",
 			}))
+		})
+	})
+
+	Describe("checks ssh enablement", func() {
+		Context("when ssh support is disabled", func() {
+			BeforeEach(func() {
+				connection.CliCommandStub = func(args ...string) ([]string, error) {
+					return []string{fmt.Sprintf("ssh support is disabled for '%s'", args[0])}, nil
+				}
+			})
+
+			It("returns false", func() {
+				result := p.CheckSshEnablement("test-app")
+
+				Expect(result).To(BeFalse())
+				cfCommands := getAllCfCommands(connection)
+
+				Expect(cfCommands).To(Equal([]string{
+					"ssh-enabled test-app",
+				}))
+			})
+		})
+
+		Context("when ssh support is enabled", func() {
+			BeforeEach(func() {
+				connection.CliCommandStub = func(args ...string) ([]string, error) {
+					return []string{fmt.Sprintf("ssh support is enabled for '%s'", args[0])}, nil
+				}
+			})
+
+			It("returns true", func() {
+				result := p.CheckSshEnablement("test-app")
+
+				Expect(result).To(BeTrue())
+				cfCommands := getAllCfCommands(connection)
+
+				Expect(cfCommands).To(Equal([]string{
+					"ssh-enabled test-app",
+				}))
+			})
+		})
+
+		Context("when cf cli errors", func() {
+			BeforeEach(func() {
+				connection.CliCommandStub = func(args ...string) ([]string, error) {
+					return nil, errors.New("failed to check ssh enablement status")
+				}
+			})
+
+			It("it reports the error", func() {
+				p.CheckSshEnablement("test-app")
+				Expect(bgdExitsWithErrors[0]).To(MatchError("failed to check ssh enablement status"))
+			})
+		})
+	})
+
+	Describe("set ssh access", func() {
+		Context("when it just works", func() {
+			It("enables ssh", func() {
+				p.SetSshAccess("test-app", true)
+
+				cfCommands := getAllCfCommands(connection)
+
+				Expect(cfCommands).To(Equal([]string{
+					"enable-ssh test-app",
+				}))
+			})
+			It("disables ssh", func() {
+				p.SetSshAccess("test-app", false)
+
+				cfCommands := getAllCfCommands(connection)
+
+				Expect(cfCommands).To(Equal([]string{
+					"disable-ssh test-app",
+				}))
+			})
+		})
+		Context("when cf enable-ssh errors", func() {
+			BeforeEach(func() {
+				connection.CliCommandStub = func(args ...string) ([]string, error) {
+					return nil, errors.New("failed to enable ssh")
+				}
+			})
+
+			It("it reports the error", func() {
+				p.SetSshAccess("test-app", true)
+				Expect(bgdExitsWithErrors[0]).To(MatchError("failed to enable ssh"))
+			})
+		})
+		Context("when cf disable-ssh errors", func() {
+			BeforeEach(func() {
+				connection.CliCommandStub = func(args ...string) ([]string, error) {
+					return nil, errors.New("failed to disable ssh")
+				}
+			})
+
+			It("it reports the error", func() {
+				p.SetSshAccess("test-app", false)
+				Expect(bgdExitsWithErrors[0]).To(MatchError("failed to disable ssh"))
+			})
 		})
 	})
 

--- a/main.go
+++ b/main.go
@@ -61,6 +61,9 @@ func (p *CfPlugin) Deploy(defaultCfDomain string, manifestReader manifest.Manife
 	// If deploy is unsuccessful, p.ErrorFunc will be called which exits.
 	p.Deployer.PushNewApp(newAppName, tempRoute, args.ManifestPath, manifestScaleParameters)
 
+	if liveAppName != "" {
+		p.Deployer.SetSshAccess(newAppName, p.Deployer.CheckSshEnablement(appName))
+	}
 	promoteNewApp := true
 	smokeTestScript := args.SmokeTestPath
 	if smokeTestScript != "" {


### PR DESCRIPTION
Ssh can be changed manually by user and should be preserved
when updating the application.