### PR TITLE
Delete temporary apps after successful deployment

### DIFF
--- a/args.go
+++ b/args.go
@@ -8,6 +8,7 @@ type Args struct {
 	SmokeTestPath string
 	ManifestPath  string
 	AppName       string
+	KeepOldApps   bool
 }
 
 func NewArgs(osArgs []string) Args {
@@ -19,6 +20,7 @@ func NewArgs(osArgs []string) Args {
 
 	f.StringVar(&args.SmokeTestPath, "smoke-test", "", "")
 	f.StringVar(&args.ManifestPath, "f", "", "")
+	f.BoolVar(&args.KeepOldApps, "keep-old-apps", false, "")
 
 	f.Parse(extractBgdArgs(osArgs))
 

--- a/args_test.go
+++ b/args_test.go
@@ -22,6 +22,10 @@ var _ = Describe("Args", func() {
 		It("does not set a manifest", func() {
 			Expect(args.ManifestPath).To(BeZero())
 		})
+
+		It("does not keep old app instances", func() {
+			Expect(args.KeepOldApps).To(BeFalse())
+		})
 	})
 
 	Context("With a smoke test and an appname", func() {
@@ -37,6 +41,10 @@ var _ = Describe("Args", func() {
 
 		It("does not set a manifest", func() {
 			Expect(args.ManifestPath).To(BeZero())
+		})
+
+		It("does not keep old app instances", func() {
+			Expect(args.KeepOldApps).To(BeFalse())
 		})
 	})
 
@@ -54,6 +62,10 @@ var _ = Describe("Args", func() {
 		It("sets a manifest", func() {
 			Expect(args.ManifestPath).To(Equal("custommanifest.yml"))
 		})
+
+		It("does not keep old app instances", func() {
+			Expect(args.KeepOldApps).To(BeFalse())
+		})
 	})
 
 	Context("With an appname and a manifest", func() {
@@ -65,6 +77,10 @@ var _ = Describe("Args", func() {
 
 		It("sets a manifest", func() {
 			Expect(args.ManifestPath).To(Equal("custommanifest.yml"))
+		})
+
+		It("does not keep old app instances", func() {
+			Expect(args.KeepOldApps).To(BeFalse())
 		})
 	})
 
@@ -81,6 +97,22 @@ var _ = Describe("Args", func() {
 
 		It("sets the app name", func() {
 			Expect(args.AppName).To(Equal("app"))
+		})
+	})
+
+	Context("With an appname and a manifest and the keep-old-apps flag", func() {
+		args := NewArgs(bgdArgs("appname -f custommanifest.yml --keep-old-apps"))
+
+		It("sets the app name", func() {
+			Expect(args.AppName).To(Equal("appname"))
+		})
+
+		It("sets a manifest", func() {
+			Expect(args.ManifestPath).To(Equal("custommanifest.yml"))
+		})
+
+		It("keeps old app instances", func() {
+			Expect(args.KeepOldApps).To(BeTrue())
 		})
 	})
 })

--- a/main.go
+++ b/main.go
@@ -102,6 +102,9 @@ func (p *CfPlugin) Deploy(cfDomains manifest.CfDomains, manifestReader manifest.
 			p.Deployer.MapRoutesToApp(newAppName, newAppRoutes...)
 			p.Deployer.RenameApp(newAppName, appName)
 		}
+		if !args.KeepOldApps {
+			p.Deployer.DeleteAllAppsExceptLiveApp(appName)
+		}
 		return true
 	} else {
 		// We don't want to promote. Instead mark it as failed.
@@ -188,10 +191,11 @@ func (p *CfPlugin) GetMetadata() plugin.PluginMetadata {
 				UsageDetails: plugin.Usage{
 					// TODO for manifests with multiple apps, a different smoke test is needed. The approach below would not work.
 					// Perhaps we could name the smoke test in the manifest?
-					Usage: "blue-green-deploy APP_NAME [--smoke-test TEST_SCRIPT] [-f MANIFEST_FILE]",
+					Usage: "blue-green-deploy APP_NAME [--smoke-test TEST_SCRIPT] [-f MANIFEST_FILE] [--keep-old-apps]",
 					Options: map[string]string{
 						"smoke-test": "The test script to run.",
 						"f":          "Path to manifest",
+						"keep-old-apps": "Don't delete old app instance(s)",
 					},
 				},
 			},

--- a/main_test.go
+++ b/main_test.go
@@ -199,7 +199,7 @@ var _ = Describe("BGD Plugin", func() {
 						"push app-name-new",
 						"unmap 1 routes from app-name-new",
 						"delete 1 routes",
-          	"mapped 4 routes",
+          					"mapped 4 routes",
 						"rename app-name-new to app-name",
 						"delete old apps",
 					}))


### PR DESCRIPTION
Don't leave behind "-old" apps as these consume resources and may lead to quota exceeded errors.
Only if the update fails (e.g. because of failed smoke tests), leave the temporary instances
for debugging.