### PR TITLE
Fixes #58

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,9 +36,10 @@ func (p *CfPlugin) Run(cliConnection plugin.CliConnection, args []string) {
 		log.Fatalf("Failed to get shared domains: %v", err)
 	}
 
-	cfDomains.DefaultDomain = cfDomains.SharedDomains[0]
-	if err != nil {
-		log.Fatalf("Failed to get default shared domain: %v", err)
+	if len(cfDomains.SharedDomains) < 1 {
+		log.Fatalf("Failed to get default shared domain (no shared domains defined)")
+	} else {
+		cfDomains.DefaultDomain = cfDomains.SharedDomains[0]
 	}
 
 	cfDomains.PrivateDomains, err = p.PrivateDomains()


### PR DESCRIPTION
This builds on 8bc41f94dfe8beca976f1fa21c1e719f18e5899e by passing through the new parameters to the manifest from main.go. It also corrects an assumption in the current code that there is always at least one shared domain.